### PR TITLE
Allow configuration of the audio backend

### DIFF
--- a/sr/comp/mixtape/audio.py
+++ b/sr/comp/mixtape/audio.py
@@ -3,15 +3,15 @@ import subprocess
 
 class AudioController:
 
-    def __init__(self):
-        self.dev_null = open('/dev/null', 'wb')
+    def __init__(self, audio_backend):
+        self.audio_backend = audio_backend
 
     def play(self, filename, output_device, trim_start):
         print('Playing', filename)
-        args = ['sox', filename, '-t', 'coreaudio']
+        args = ['sox', filename, '-t', self.audio_backend]
         if output_device is not None:
             args.append(output_device)
         if trim_start != 0:
             args += ['trim', str(trim_start)]
 
-        return subprocess.Popen(args, stdout=self.dev_null, stderr=self.dev_null)
+        return subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -57,7 +57,7 @@ def get_match_schedule(base_url, start_time):
     return requests.get(url, params=params).json()
 
 
-def play_track(filename, magicq_playback, magicq_cue, generation_number, output_device, group, trim_start, audio_backend):
+def play_track(filename, magicq_playback, magicq_cue, generation_number, output_device, group, trim_start, audio_controller):
     global exclusivity_groups
 
     if generation_number != current_generation:
@@ -72,7 +72,7 @@ def play_track(filename, magicq_playback, magicq_cue, generation_number, output_
             if existing_process is not None:
                 existing_process.terminate()
 
-        process = AudioController(audio_backend).play(filename, output_device, trim_start)
+        process = audio_controller.play(filename, output_device, trim_start)
 
         if group is not None:
             exclusivity_groups[group] = process
@@ -90,6 +90,8 @@ def play(args):
         magicq_playback = config['playback']
 
     prev_match = None
+
+    audio_controller = AudioController(args.audio_backend)
 
     stream = SSEClient(args.stream)
     for message in stream:
@@ -147,7 +149,7 @@ def play(args):
                 print('Scheduling', name, 'for', track['start'])
                 schedule.enterabs(track['start'], 0, play_track,
                                   argument=(path, magicq_playback, magicq_cue, current_generation,
-                                            output_device, group, trim_start, args.audio_backend))
+                                            output_device, group, trim_start, audio_controller))
 
             thread = Thread(target=schedule.run)
             thread.daemon = True


### PR DESCRIPTION
This PR allows configuration of the audio backend passed through to `sox`. 

This means `mixtape` now natively supports OS' other than macOS! :tada: 