### PR TITLE
MagicQ playback varies by cue, so remove the global

### DIFF
--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -79,7 +79,7 @@ def play_track(filename, magicq_playback, magicq_cue, generation_number, output_
 
 
 def play(args):
-    global current_generation, magicq_controller, magicq_playback
+    global current_generation, magicq_controller
 
     with open(os.path.join(args.mixtape, 'playlist.yaml')) as file:
         playlist = yaml.safe_load(file)
@@ -87,7 +87,6 @@ def play(args):
     if 'magicq' in playlist:
         config = playlist['magicq']
         magicq_controller = MagicqController((config['host'], config['port']))
-        magicq_playback = config['playback']
 
     prev_match = None
 
@@ -127,6 +126,7 @@ def play(args):
             for track in tracks:
                 try:
                     magicq_cue = None
+                    magicq_playback = None
                     path = os.path.join(args.mixtape, track['filename'])
 
                     # load into filesystem cache


### PR DESCRIPTION
This was apparently originally assumed to be a global thing, but in fact varies by cue. Since that's the case, remove the global variable and instead force it to be specified for each cue explicitly.