### PR TITLE
Support OBS video playback

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,10 @@ time it takes to decode compressed audio, which can throw off timings.
     installed. This requires the following nested keys:
     - ``port``: the websocket port for the (probably `4444`)
     - ``password``: the password for the websocket
-    - ``source_name``: the name of the "Source" within OBS Studio that will play the videos
-    - ``scene_name``: the name of the "Scene" within OBS Studio that contains the above Source
+    - ``source_name``: the name of the "Source" within OBS Studio that will play the videos.
+        The source being controlled the option "Close file when inactive" needs to be set to allow the source to be changed when not active.
+    - ``scene_name``: the name of the "Scene" within OBS Studio that contains the above Source.
+        The scene being transitioned to needs "Transition Override > Fade" selected so there is a fade.
 
 Track configuration
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,6 @@ time it takes to decode compressed audio, which can throw off timings.
 - ``obs_studio`` defines the connection settings to an instance of OBS Studio
     which has the `obs-websocket plugin <https://github.com/Palakis/obs-websocket>`_
     installed. This requires the following nested keys:
-    - ``host``: the websocket host for the (probably `localhost`)
     - ``port``: the websocket port for the (probably `4444`)
     - ``password``: the password for the websocket
     - ``source_name``: the name of the "Source" within OBS Studio that will play the videos

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ time it takes to decode compressed audio, which can throw off timings.
     - ``port``: the websocket port for the (probably `4444`)
     - ``password``: the password for the websocket
     - ``source_name``: the name of the "Source" within OBS Studio that will play the videos
+    - ``scene_name``: the name of the "Scene" within OBS Studio that contains the above Source
 
 Track configuration
 -------------------
@@ -71,6 +72,8 @@ Or:
 Or:
 
 - ``obs_video`` is the path to a video file which should be played by OBS Studio.
+  The track start should be set to -2 seconds as the playback includes a transition
+  to the scene ahead of the start of the match.
 
 
 .. |Build Status| image:: https://circleci.com/gh/srobo/srcomp-mixtape.svg?style=svg

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,13 @@ time it takes to decode compressed audio, which can throw off timings.
 - ``magicq`` defines the MagicQ connection settings, for automatic triggering of lights.
 - ``tracks`` defines the triggers and tracks to be played in a specific match, as a giant dictionary of the match number to track configuration.
 - ``all`` defines the triggers and tracks to be played in *every* match, in the same format as a single match in ``tracks``.
-
+- ``obs_studio`` defines the connection settings to an instance of OBS Studio
+    which has the `obs-websocket plugin <https://github.com/Palakis/obs-websocket>`_
+    installed. This requires the following nested keys:
+    - ``host``: the websocket host for the (probably `localhost`)
+    - ``port``: the websocket port for the (probably `4444`)
+    - ``password``: the password for the websocket
+    - ``source_name``: the name of the "Source" within OBS Studio that will play the videos
 
 Track configuration
 -------------------
@@ -61,6 +67,10 @@ Or:
 
 - ``magicq_cue`` is the MagicQ cue ID to send.
 - ``magicq_playback`` is the MagicQ playlist ID to send.
+
+Or:
+
+- ``obs_video`` is the path to a video file which should be played by OBS Studio.
 
 
 .. |Build Status| image:: https://circleci.com/gh/srobo/srcomp-mixtape.svg?style=svg

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'requests >=2.5, <3',
         'ruamel.yaml >=0.15, <0.16',
         'sseclient >=0.0, <1',
+        'obs-websocket-py >=0.5.3, <0.6',
         'python-dateutil >=2.4, <3',
         'typing-extensions >=3.7.4.3, <4',
     ],

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -81,6 +81,7 @@ def play(args):
             config['port'],
             config['password'],
             config['source_name'],
+            config['scene_name'],
         )
 
     audio_controller = AudioController(args.audio_backend)

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -8,6 +8,7 @@ from ruamel import yaml
 from .audio import AudioController
 from .magicq import MagicqController
 from .mixtape import Mixtape
+from .obs_studio import OBSStudioController
 from .scheduling import Scheduler
 
 
@@ -54,9 +55,25 @@ def play(args):
         config = playlist['magicq']
         magicq_controller = MagicqController((config['host'], config['port']))
 
+    obs_controller = None
+    if 'obs_studio' in playlist:
+        config = playlist['obs_studio']
+        obs_controller = OBSStudioController(
+            config['host'],
+            config['port'],
+            config['password'],
+            config['source_name'],
+        )
+
     audio_controller = AudioController(args.audio_backend)
 
-    mixtape = Mixtape(args.mixtape, playlist, audio_controller, magicq_controller)
+    mixtape = Mixtape(
+        args.mixtape,
+        playlist,
+        audio_controller,
+        magicq_controller,
+        obs_controller,
+    )
 
     scheduler = Scheduler(
         api_url=args.api,

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -77,7 +77,6 @@ def play(args):
     if 'obs_studio' in playlist:
         config = playlist['obs_studio']
         obs_controller = OBSStudioController(
-            config['host'],
             config['port'],
             config['password'],
             config['source_name'],

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 from .audio import AudioController
 from .magicq import MagicqController
+from .obs_studio import OBSStudioController
 from .scheduling import Action
 
 
@@ -23,12 +24,33 @@ class Mixtape:
         playlist: Any,
         audio_controller: AudioController,
         magicq_controller: Optional[MagicqController],
+        obs_studio_controller: Optional[OBSStudioController],
     ) -> None:
         self.root = root
         self.playlist = playlist
         self.audio_controller = audio_controller
         self.exclusivity_groups: Dict[object, subprocess.Popen[bytes]] = {}
         self.magicq_controller = magicq_controller
+        self.obs_studio_controller = obs_studio_controller
+
+    def get_play_video_action(
+        self,
+        track: Any,
+        current_offset: Callable[[], float],
+    ) -> Tuple[Action, str]:
+        path = os.path.join(self.root, track['obs_video'])
+        preload(path)
+
+        if self.obs_studio_controller is None:
+            raise ValueError(f"Need a obs_studio_controller to play {path}")
+        controller = self.obs_studio_controller
+
+        name = f'OBSStudio({path})'
+
+        def action() -> None:
+            controller.play_video(path)
+
+        return action, name
 
     def play_track(self, filename, output_device, group, trim_start):
         if group is not None:
@@ -97,6 +119,8 @@ class Mixtape:
                 action, name = self.get_play_track_action(track, current_offset)
             elif 'magicq_playback' in track:
                 action, name = self.get_run_cue_action(track, current_offset)
+            elif 'obs_video' in track:
+                action, name = self.get_play_video_action(track, current_offset)
             else:
                 raise ValueError(f"Unknown track type at index {idx} start:{track['start']}")
 

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -8,6 +8,14 @@ from .magicq import MagicqController
 from .scheduling import Action
 
 
+def preload(filename: str):
+    """
+    Helper to force a file into the filesystem cache.
+    """
+    with open(filename, mode='rb') as f:
+        f.read(1)
+
+
 class Mixtape:
     def __init__(
         self,
@@ -47,9 +55,7 @@ class Mixtape:
         output_device = track.get('output_device', None)
         group = track.get('group', None)
 
-        # load into filesystem cache
-        with open(path, 'rb') as file:
-            file.read(1)
+        preload(path)
 
         action = functools.partial(
             self.play_track,

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -26,7 +26,7 @@ class Mixtape:
         magicq_controller: Optional[MagicqController],
         obs_studio_controller: Optional[OBSStudioController],
     ) -> None:
-        self.root = root
+        self.root = os.path.abspath(root)
         self.playlist = playlist
         self.audio_controller = audio_controller
         self.exclusivity_groups: Dict[object, subprocess.Popen[bytes]] = {}

--- a/sr/comp/mixtape/obs_studio.py
+++ b/sr/comp/mixtape/obs_studio.py
@@ -1,0 +1,73 @@
+import threading
+from types import TracebackType
+from typing import Generic, Optional, Type, TypeVar
+
+from obswebsocket import obsws, requests  # type: ignore[import]
+
+T = TypeVar('T')
+
+
+class Guarded(Generic[T]):
+    """
+    A generic mechanism to protect an object which may need to be accessed from
+    several threads.
+    """
+
+    def __init__(self, value: T) -> None:
+        self._value = value
+        self._lock = threading.Lock()
+
+    def __enter__(self) -> T:
+        self._lock.__enter__()
+        return self._value
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        return self._lock.__exit__(exc_type, exc_val, exc_tb)
+
+
+class OBSStudioController:
+    """
+    Connect to an instance of OBS Studio via the obs-websocket plugin.
+
+    See https://github.com/Palakis/obs-websocket for the plugin's details.
+    """
+
+    def __init__(self, host: str, port: int, password: str, source: str) -> None:
+        websocket = obsws(host, port, password)
+        websocket.connect()
+
+        self.source_name = source
+        self.video_info = websocket.call(requests.GetVideoInfo())
+
+        # Our play_video method is going to be called from one of the (possibly
+        # many) worker threads which the scheduler will use. Guard it against
+        # concurrent access.
+        self.websocket = Guarded(websocket)
+
+    def play_video(self, filename: str) -> None:
+        with self.websocket as websocket:
+            websocket.call(requests.SetSourceSettings(
+                self.source_name,
+                {
+                    'local_file': filename,
+                    'looping': False,
+                    'restart_on_activate': False,
+                    'clear_on_media_end': False,
+                },
+            ))
+
+            websocket.call(requests.SetSceneItemProperties(
+                {'name': self.source_name},
+                # Setting the bounds here means that the media will fill the canvas,
+                # preserving its aspect ratio.
+                bounds={
+                    'type': 'OBS_BOUNDS_SCALE_INNER',
+                    'x': self.video_info.getBaseWidth(),
+                    'y': self.video_info.getBaseHeight(),
+                },
+            ))

--- a/sr/comp/mixtape/obs_studio.py
+++ b/sr/comp/mixtape/obs_studio.py
@@ -7,6 +7,8 @@ from obswebsocket import obsws, requests  # type: ignore[import]
 
 T = TypeVar('T')
 
+PLAY, PAUSE = False, True
+
 
 class Guarded(Generic[T]):
     """
@@ -81,11 +83,12 @@ class OBSStudioController:
                 },
             ))
 
-            # Rely on stopping the media also resetting back to the start
-            websocket.call(requests.StopMedia(self.source_name))
+            websocket.call(requests.PlayPauseMedia(self.source_name, PAUSE))
+            websocket.call(requests.ScrubMedia(self.source_name, 0))
+
+            websocket.call(requests.SetCurrentScene(self.scene_name))
 
             # TODO: remove this hardcoding
             time.sleep(2)
 
-            websocket.call(requests.SetCurrentScene(self.scene_name))
-            websocket.call(requests.RestartMedia(self.source_name))
+            websocket.call(requests.PlayPauseMedia(self.source_name, PLAY))

--- a/sr/comp/mixtape/obs_studio.py
+++ b/sr/comp/mixtape/obs_studio.py
@@ -42,13 +42,12 @@ class OBSStudioController:
 
     def __init__(
         self,
-        host: str,
         port: int,
         password: str,
         source: str,
         scene: str,
     ) -> None:
-        websocket = obsws(host, port, password)
+        websocket = obsws('localhost', port, password)
         websocket.connect()
 
         self.source_name = source


### PR DESCRIPTION
This does some further refactoring to simplify things and then introduces support for telling OBS to play videos via [obs-websocket-py](https://pypi.org/project/obs-websocket-py/).

This itself isn't tested, though I have previously tested OBS websocket usage like this in https://github.com/PeterJCLaw/obs-match-scheduler/blob/main/via-obs-websocket-py.

Fixes https://github.com/srobo/tasks/issues/655.