### PR TITLE
OBS tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,8 +76,8 @@ Or:
 Or:
 
 - ``obs_video`` is the path to a video file which should be played by OBS Studio.
-  The track start should be set to -preload_time seconds as the playback includes a transition
-  to the scene ahead of the start of the match.
+  The track start corresponds to the point where the video begins playing.
+  The video will be loaded and transitioned to ``preload_time`` seconds before this.
 
 
 .. |Build Status| image:: https://circleci.com/gh/srobo/srcomp-mixtape.svg?style=svg

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ time it takes to decode compressed audio, which can throw off timings.
     The source being controlled the option "Close file when inactive" needs to be set to allow the source to be changed when not active.
   - ``scene_name``: the name of the "Scene" within OBS Studio that contains the above Source.
     The scene being transitioned to needs "Transition Override > Fade" selected so there is a fade.
+  - ``preload_time``: the period, in seconds, before a video is played that it should be loaded and transitioned to.
 
 Track configuration
 -------------------
@@ -75,7 +76,7 @@ Or:
 Or:
 
 - ``obs_video`` is the path to a video file which should be played by OBS Studio.
-  The track start should be set to -2 seconds as the playback includes a transition
+  The track start should be set to -preload_time seconds as the playback includes a transition
   to the scene ahead of the start of the match.
 
 

--- a/example-playlist.yaml
+++ b/example-playlist.yaml
@@ -3,6 +3,7 @@ obs_studio:
   password: password          # The websocket password set in OBS
   source_name: 'Media Source' # The name of the source which obs_video cues are played in
   scene_name: Scene           # The name of the scene which the source is on
+  preload_time: 5             # The number of seconds before an obs_video track that the video is loaded and transitioned to
 magicq:
   host: 127.0.0.1
   port: 6553  # default Chamsys MagicQ port
@@ -34,5 +35,5 @@ tracks:
       magicq_playback: 1
       magicq_cue: 2
   1:  # play recorded video in OBS for match 1
-    - start: -2
+    - start: 0
       obs_video: 'match-1.mp4'

--- a/example-playlist.yaml
+++ b/example-playlist.yaml
@@ -1,3 +1,8 @@
+obs_studio:
+  port: 4444                  # The websocket port set in OBS
+  password: password          # The websocket password set in OBS
+  source_name: 'Media Source' # The name of the source which obs_video cues are played in
+  scene_name: Scene           # The name of the scene which the source is on
 magicq:
   host: 127.0.0.1
   port: 6553  # default Chamsys MagicQ port
@@ -28,3 +33,6 @@ tracks:
     - start: -5
       magicq_playback: 1
       magicq_cue: 2
+  1:  # play recorded video in OBS for match 1
+    - start: -2
+      obs_video: 'match-1.mp4'

--- a/example-playlist.yaml
+++ b/example-playlist.yaml
@@ -3,7 +3,7 @@ obs_studio:
   password: password          # The websocket password set in OBS
   source_name: 'Media Source' # The name of the source which obs_video cues are played in
   scene_name: Scene           # The name of the scene which the source is on
-  preload_time: 5             # The number of seconds before an obs_video track that the video is loaded and transitioned to
+  preroll_time: 5             # The number of seconds before an obs_video track that the video is loaded and transitioned to
 magicq:
   host: 127.0.0.1
   port: 6553  # default Chamsys MagicQ port

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -81,7 +81,7 @@ def play(args):
             config['password'],
             config['source_name'],
             config['scene_name'],
-            config.get('preload_time', 2),
+            config.get('preroll_time', 2),
         )
 
     audio_controller = AudioController(args.audio_backend)

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -81,6 +81,7 @@ def play(args):
             config['password'],
             config['source_name'],
             config['scene_name'],
+            config.get('preload_time', 2),
         )
 
     audio_controller = AudioController(args.audio_backend)

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -81,7 +81,7 @@ def play(args):
             config['password'],
             config['source_name'],
             config['scene_name'],
-            config.get('preroll_time', 2),
+            config['preroll_time'],
         )
 
     audio_controller = AudioController(args.audio_backend)

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -48,7 +48,7 @@ class Mixtape:
         def action() -> None:
             controller.load_video(path)
 
-        return action, controller.preload_time
+        return action, controller.preroll_time
 
     def get_play_video_action(
         self,
@@ -146,10 +146,10 @@ class Mixtape:
             elif 'magicq_playback' in track:
                 action, name = self.get_run_cue_action(track, current_offset)
             elif 'obs_video' in track:
-                load_action, preload_time = self.get_load_video_action(track, current_offset)
+                load_action, preroll_time = self.get_load_video_action(track, current_offset)
                 # priority 1 used since timing of load not critical
                 # and we don't want to delay other actions
-                yield track['start'] - preload_time, 1, load_action
+                yield track['start'] - preroll_time, 1, load_action
                 action, name = self.get_play_video_action(track, current_offset)
             else:
                 raise ValueError(f"Unknown track type at index {idx} start:{track['start']}")

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -33,13 +33,29 @@ class Mixtape:
         self.magicq_controller = magicq_controller
         self.obs_studio_controller = obs_studio_controller
 
+    def get_load_video_action(
+        self,
+        track: Any,
+        current_offset: Callable[[], float],
+    ) -> Tuple[Action, float]:
+        path = os.path.join(self.root, track['obs_video'])
+        preload(path)
+
+        if self.obs_studio_controller is None:
+            raise ValueError(f"Need a obs_studio_controller to play {path}")
+        controller = self.obs_studio_controller
+
+        def action() -> None:
+            controller.load_video(path)
+
+        return action, controller.preload_time
+
     def get_play_video_action(
         self,
         track: Any,
         current_offset: Callable[[], float],
     ) -> Tuple[Action, str]:
         path = os.path.join(self.root, track['obs_video'])
-        preload(path)
 
         if self.obs_studio_controller is None:
             raise ValueError(f"Need a obs_studio_controller to play {path}")
@@ -48,7 +64,7 @@ class Mixtape:
         name = f'OBSStudio({path})'
 
         def action() -> None:
-            controller.play_video(path)
+            controller.play_video()
 
         return action, name
 
@@ -130,6 +146,10 @@ class Mixtape:
             elif 'magicq_playback' in track:
                 action, name = self.get_run_cue_action(track, current_offset)
             elif 'obs_video' in track:
+                load_action, preload_time = self.get_load_video_action(track, current_offset)
+                # priority 1 used since timing of load not critical
+                # and we don't want to delay other actions
+                yield track['start'] - preload_time, 1, load_action
                 action, name = self.get_play_video_action(track, current_offset)
             else:
                 raise ValueError(f"Unknown track type at index {idx} start:{track['start']}")

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -48,6 +48,10 @@ class Mixtape:
         def action() -> None:
             controller.load_video(path)
 
+        print(
+            f"Scheduling load OBSStudio({path}) for",
+            track['start'] - controller.preroll_time,
+        )
         return action, controller.preroll_time
 
     def get_play_video_action(

--- a/sr/comp/mixtape/obs_studio.py
+++ b/sr/comp/mixtape/obs_studio.py
@@ -46,12 +46,14 @@ class OBSStudioController:
         password: str,
         source: str,
         scene: str,
+        preload_time: float,
     ) -> None:
         websocket = obsws('localhost', port, password)
         websocket.connect()
 
         self.source_name = source
         self.scene_name = scene
+        self.preload_time = preload_time
         self.video_info = websocket.call(requests.GetVideoInfo())
 
         # Our play_video method is going to be called from one of the (possibly
@@ -88,6 +90,6 @@ class OBSStudioController:
             websocket.call(requests.SetCurrentScene(self.scene_name))
 
             # TODO: remove this hardcoding
-            time.sleep(2)
+            time.sleep(self.preload_time)
 
             websocket.call(requests.PlayPauseMedia(self.source_name, PLAY))

--- a/sr/comp/mixtape/obs_studio.py
+++ b/sr/comp/mixtape/obs_studio.py
@@ -45,14 +45,14 @@ class OBSStudioController:
         password: str,
         source: str,
         scene: str,
-        preload_time: float,
+        preroll_time: float,
     ) -> None:
         websocket = obsws('localhost', port, password)
         websocket.connect()
 
         self.source_name = source
         self.scene_name = scene
-        self.preload_time = preload_time
+        self.preroll_time = preroll_time
         self.video_info = websocket.call(requests.GetVideoInfo())
 
         # Our play_video method is going to be called from one of the (possibly

--- a/sr/comp/mixtape/obs_studio.py
+++ b/sr/comp/mixtape/obs_studio.py
@@ -1,5 +1,4 @@
 import threading
-import time
 from types import TracebackType
 from typing import Generic, Optional, Type, TypeVar
 
@@ -61,7 +60,7 @@ class OBSStudioController:
         # concurrent access.
         self.websocket = Guarded(websocket)
 
-    def play_video(self, filename: str) -> None:
+    def load_video(self, filename: str) -> None:
         with self.websocket as websocket:
             websocket.call(requests.SetSourceSettings(
                 self.source_name,
@@ -89,7 +88,6 @@ class OBSStudioController:
 
             websocket.call(requests.SetCurrentScene(self.scene_name))
 
-            # TODO: remove this hardcoding
-            time.sleep(self.preload_time)
-
+    def play_video(self) -> None:
+        with self.websocket as websocket:
             websocket.call(requests.PlayPauseMedia(self.source_name, PLAY))


### PR DESCRIPTION
- adds a global option for pre-play transition time: `preload_time`
- splits load-transition and play into separate scheduler events
- changes obs-video action start time to point at when video playback commences
- updates `example_playlist.yaml` to include OBS config