### PR TITLE
Allow video filenames to use a placeholder for match number

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Or:
 - ``obs_video`` is the path to a video file which should be played by OBS Studio.
   The track start corresponds to the point where the video begins playing.
   The video will be loaded and transitioned to ``preload_time`` seconds before this.
-  ``obs_video`` also supports using the placeholder ``{match}`` in the filename given,
+  ``obs_video`` also supports using the placeholder ``{match_num}`` in the filename given,
   this is substituted for the match number each time the action is used.
 
 Or:

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,8 @@ Or:
 - ``obs_video`` is the path to a video file which should be played by OBS Studio.
   The track start corresponds to the point where the video begins playing.
   The video will be loaded and transitioned to ``preload_time`` seconds before this.
+  ``obs_video`` also supports using the placeholder ``{match}`` in the filename given,
+  this is substituted for the match number each time the action is used.
 
 Or:
 

--- a/example-playlist.yaml
+++ b/example-playlist.yaml
@@ -22,7 +22,7 @@ all:
     filename: match_start.wav
     output_device:
     group: start-sounds
-  # Run unique match videos fo each match
+  # Run unique match videos for each match
   - start: 0
     obs_video: match-{match_num}.mp4
   # End-of-match events (assuming 120s match)

--- a/example-playlist.yaml
+++ b/example-playlist.yaml
@@ -22,6 +22,9 @@ all:
     filename: match_start.wav
     output_device:
     group: start-sounds
+  # Run unique match videos fo each match
+  - start: 0
+    obs_video: match-{match_num}.mp4
   # End-of-match events (assuming 120s match)
   - start: 120
     magicq_playback: 2

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -126,7 +126,7 @@ def verify_tracks(mixtape_dir, tracks, matches):
         except KeyError:
             try:
                 filename = track['obs_video']
-                if '{match' in filename:
+                if '{match_num' in filename:
                     if matches:
                         for match in range(match_start, match_end + 1):
                             match_filename = populate_filename_placeholder(filename, match)

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -111,6 +111,9 @@ def verify_tracks(mixtape_dir, tracks):
         except KeyError:
             try:
                 filename = track['obs_video']
+                if '{match' in filename:
+                    print('Video file name contains a match placeholder, this is not tested')
+                    continue
             except KeyError:
                 continue
         path = os.path.join(mixtape_dir, filename)

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -141,6 +141,7 @@ def verify_tracks(mixtape_dir, tracks, matches):
         except KeyError:
             try:
                 filename = track['obs_video']
+                # The trailing brace is omitted so that placeholders with formatting are caught
                 if '{match_num' in filename:
                     if matches:
                         for match in matches:

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -2,6 +2,7 @@ import os.path
 import time
 from argparse import ArgumentParser
 from datetime import timedelta
+from typing import List, Set
 
 from ruamel import yaml
 

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -19,7 +19,7 @@ def preload(filename: str):
 
 def populate_filename_placeholder(filename: str, match_num: int) -> str:
     try:
-        return filename.format(match=match_num)
+        return filename.format(match_num=match_num)
     except KeyError:
         return filename
 

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -48,6 +48,9 @@ class Mixtape:
     ) -> Tuple[Action, float]:
         filename = populate_filename_placeholder(track['obs_video'], match_num)
         path = os.path.join(self.root, filename)
+        if not os.path.exists(path):
+            print(f"File {path} could not be found, skipping")
+            raise FileNotFoundError
         preload(path)
 
         if self.obs_studio_controller is None:
@@ -179,15 +182,18 @@ class Mixtape:
             elif 'magicq_playback' in track:
                 action, name = self.get_run_cue_action(track, current_offset)
             elif 'obs_video' in track:
-                load_action, preroll_time = self.get_load_video_action(
-                    track,
-                    current_offset,
-                    num,
-                )
-                # priority 1 used since timing of load not critical
-                # and we don't want to delay other actions
-                yield track['start'] - preroll_time, 1, load_action
-                action, name = self.get_play_video_action(track, current_offset, num)
+                try:
+                    load_action, preroll_time = self.get_load_video_action(
+                        track,
+                        current_offset,
+                        num,
+                    )
+                    # priority 1 used since timing of load not critical
+                    # and we don't want to delay other actions
+                    yield track['start'] - preroll_time, 1, load_action
+                    action, name = self.get_play_video_action(track, current_offset, num)
+                except FileNotFoundError:
+                    continue
             else:
                 raise ValueError(f"Unknown track type at index {idx} start:{track['start']}")
 

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -188,12 +188,12 @@ class Mixtape:
                         current_offset,
                         num,
                     )
-                    # priority 1 used since timing of load not critical
-                    # and we don't want to delay other actions
-                    yield track['start'] - preroll_time, 1, load_action
-                    action, name = self.get_play_video_action(track, current_offset, num)
                 except FileNotFoundError:
                     continue
+                # priority 1 used since timing of load not critical
+                # and we don't want to delay other actions
+                yield track['start'] - preroll_time, 1, load_action
+                action, name = self.get_play_video_action(track, current_offset, num)
             else:
                 raise ValueError(f"Unknown track type at index {idx} start:{track['start']}")
 

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -18,10 +18,7 @@ def preload(filename: str):
 
 
 def populate_filename_placeholder(filename: str, match_num: int) -> str:
-    try:
-        return filename.format(match_num=match_num)
-    except KeyError:
-        return filename
+    return filename.format(match_num=match_num)
 
 
 class Mixtape:

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -191,6 +191,8 @@ class Mixtape:
                 # and we don't want to delay other actions
                 yield track['start'] - preroll_time, 1, load_action
                 action, name = self.get_play_video_action(track, current_offset, num)
+            elif 'obs_scene' in track:
+                action, name = self.get_transition_scene_action(track, current_offset)
             else:
                 raise ValueError(f"Unknown track type at index {idx} start:{track['start']}")
 


### PR DESCRIPTION
Allows the filename specified in the obs_video track to be specified as `match-{match}.mp4` where `{match}` is replaced with with each match number. Also adds support for the verify command to take the range of match numbers to be tested against the placeholder.

Ideally this PR would be applied against #14 since the first 4 commits are that branch, as such this should be applied after it.