### PR TITLE
Convert Magicq to use OSC commands

### DIFF
--- a/example-playlist.yaml
+++ b/example-playlist.yaml
@@ -6,7 +6,7 @@ obs_studio:
   preroll_time: 5             # The number of seconds before an obs_video track that the video is loaded and transitioned to
 magicq:
   host: 127.0.0.1
-  port: 53000  # default Chamsys MagicQ OSC port
+  port: 8000  # default Chamsys MagicQ OSC port
 all:
   # An example lighting cue action
   - start: -15              # Time, in seconds, relative to the match start time

--- a/example-playlist.yaml
+++ b/example-playlist.yaml
@@ -6,7 +6,7 @@ obs_studio:
   preroll_time: 5             # The number of seconds before an obs_video track that the video is loaded and transitioned to
 magicq:
   host: 127.0.0.1
-  port: 6553  # default Chamsys MagicQ port
+  port: 53000  # default Chamsys MagicQ OSC port
 all:
   # An example lighting cue action
   - start: -15              # Time, in seconds, relative to the match start time

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'obs-websocket-py >=0.5.3, <0.6',
         'python-dateutil >=2.4, <3',
         'typing-extensions >=3.7.4.3, <4',
+        'python-osc >=1.8.0, <2',
     ],
     python_requires='>=3.7',
     entry_points={

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -1,5 +1,6 @@
 import os.path
 import time
+import warnings
 from argparse import ArgumentParser
 from datetime import timedelta
 from typing import List, Set
@@ -96,7 +97,10 @@ def play(args):
     if 'magicq' in playlist:
         config = playlist['magicq']
         if config['port'] == 6553:
-            print("WARNING: you are using the default magicq remote protocol port. Are you sure your OSC receive port is 6553")
+            warnings.warn(
+                "You are using the default magicq remote protocol port. "
+                "Are you sure your OSC receive port is 6553?"
+            )
         magicq_controller = MagicqController(config['host'], config['port'])
 
     obs_controller = None

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -176,7 +176,7 @@ def test(args):
     magicq_controller = MagicqController(config['host'], config['port'])
 
     magicq_controller.jump_to_cue(4, 2)
-    time.sleep(1)
+    time.sleep(10)
     # magicq_controller.jump_to_cue(3, 2.5)
 
 

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -99,7 +99,7 @@ def play(args):
         if config['port'] == 6553:
             warnings.warn(
                 "You are using the default magicq remote protocol port. "
-                "Are you sure your OSC receive port is 6553?"
+                "Are you sure your OSC receive port is 6553?",
             )
         magicq_controller = MagicqController(config['host'], config['port'])
 

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -95,6 +95,8 @@ def play(args):
     magicq_controller = None
     if 'magicq' in playlist:
         config = playlist['magicq']
+        if config['port'] == 6553:
+            print("WARNING: you are using the default magicq remote protocol port. Are you sure your OSC receive port is 6553")
         magicq_controller = MagicqController(config['host'], config['port'])
 
     obs_controller = None

--- a/sr/comp/mixtape/cli.py
+++ b/sr/comp/mixtape/cli.py
@@ -95,7 +95,7 @@ def play(args):
     magicq_controller = None
     if 'magicq' in playlist:
         config = playlist['magicq']
-        magicq_controller = MagicqController((config['host'], config['port']))
+        magicq_controller = MagicqController(config['host'], config['port'])
 
     obs_controller = None
     if 'obs_studio' in playlist:
@@ -173,11 +173,11 @@ def test(args):
         playlist = yaml.safe_load(file)
 
     config = playlist['magicq']
-    magicq_controller = MagicqController((config['host'], config['port']))
+    magicq_controller = MagicqController(config['host'], config['port'])
 
-    magicq_controller.jump_to_cue(4, 2, 0)
+    magicq_controller.jump_to_cue(4, 2)
     time.sleep(1)
-    # magicq_controller.jump_to_cue(3, 2, 0)
+    # magicq_controller.jump_to_cue(3, 2.5)
 
 
 def main():

--- a/sr/comp/mixtape/magicq.py
+++ b/sr/comp/mixtape/magicq.py
@@ -1,32 +1,18 @@
-import socket
-import struct
-from typing import Tuple
+from typing import Union
+
+from pythonosc.udp_client import SimpleUDPClient
 
 
 class MagicqController:
 
-    def __init__(self, address: Tuple[str, int]) -> None:
-        self.address = address
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    def __init__(self, host: str, port: int) -> None:
+        self.osc_client = SimpleUDPClient(host, port)
 
-    @staticmethod
-    def build_packet(data: bytes) -> bytes:
-        length = struct.pack('<H', len(data))
-        return b'CREP\0\0\0\0' + length + data
+    def activate_playback(self, playback: int) -> None:
+        self.osc_client.send_message(f'/pb/{playback}/go', None)
 
-    def send_command_once(self, command: str) -> None:
-        self.send_command(command, 1)
+    def release_playback(self, playback: int) -> None:
+        self.osc_client.send_message(f'/pb/{playback}/release', None)
 
-    def send_command(self, command: str, retries: int = 5) -> None:
-        packet = self.build_packet(command.encode('ascii'))
-        for _retry in range(retries):
-            self.socket.sendto(packet, self.address)
-
-    def activate_playback(self, num: int) -> None:
-        self.send_command(f'{num}A')
-
-    def release_playback(self, num: int) -> None:
-        self.send_command(f'{num}R')
-
-    def jump_to_cue(self, playback: int, cue_id: int, cue_id_dec: int) -> None:
-        self.send_command(f'{playback},{cue_id},{cue_id_dec}J')
+    def jump_to_cue(self, playback: int, cue_id: Union[int, float, str]) -> None:
+        self.osc_client.send_message(f'/pb/{playback}/{cue_id}', None)

--- a/sr/comp/mixtape/magicq.py
+++ b/sr/comp/mixtape/magicq.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from pythonosc.udp_client import SimpleUDPClient
+from pythonosc.udp_client import SimpleUDPClient  # type: ignore[import]
 
 
 class MagicqController:

--- a/sr/comp/mixtape/magicq.py
+++ b/sr/comp/mixtape/magicq.py
@@ -9,10 +9,10 @@ class MagicqController:
         self.osc_client = SimpleUDPClient(host, port)
 
     def activate_playback(self, playback: int) -> None:
-        self.osc_client.send_message(f'/pb/{playback}/go', None)
+        self.osc_client.send_message(f'/pb/{playback}/go', [])
 
     def release_playback(self, playback: int) -> None:
-        self.osc_client.send_message(f'/pb/{playback}/release', None)
+        self.osc_client.send_message(f'/pb/{playback}/release', [])
 
     def jump_to_cue(self, playback: int, cue_id: Union[int, float, str]) -> None:
-        self.osc_client.send_message(f'/pb/{playback}/{cue_id}', None)
+        self.osc_client.send_message(f'/pb/{playback}/{cue_id}', [])

--- a/sr/comp/mixtape/mixtape.py
+++ b/sr/comp/mixtape/mixtape.py
@@ -161,7 +161,7 @@ class Mixtape:
         name = f'MagicQ({magicq_playback}, {magicq_cue})'
 
         def action() -> None:
-            controller.jump_to_cue(magicq_playback, magicq_cue, 0)
+            controller.jump_to_cue(magicq_playback, magicq_cue)
 
         return action, name
 


### PR DESCRIPTION
Open Sound Control (OSC) is a more universal protocol for automating AV equipment. Magicq also works more reliably with OSC than its proprietary Remote Ethernet Protocol.

Also happens to solve #5.