### PR TITLE
Reload matches if current delay changes

### DIFF
--- a/sr/comp/mixtape/scheduling.py
+++ b/sr/comp/mixtape/scheduling.py
@@ -124,11 +124,11 @@ class Scheduler:
         prev_match: Optional[Match] = None
 
         for message in self.stream:
-            if message.event != 'match':
+            if message.event not in ('match', 'current-delay'):
                 continue
 
             matches = json.loads(message.data)
-            if matches:
+            if message.event == 'match' and matches:
                 match: Match = matches[0]
             else:
                 try:


### PR DESCRIPTION
This allows mixtape to account for changes in delay which don't change the list of current matches (and thus the stream doesn't emit a `match` event). This can definitely happen if that list is empty (and remains so), perhaps when _during_ another delay.

Relates to https://github.com/srobo/tasks/issues/1207.